### PR TITLE
Fix conversions from Date instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "date-string-fns",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A set of functions for handling ISO-8601 date strings",
   "author": "adelphes",
   "license": "MIT",
-  "repository": "adelphes/date-string-fns",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adelphes/date-string-fns.git"
+  },
   "keywords": [
     "date",
     "date-fns",
@@ -18,5 +21,13 @@
   "types": "lib/index.d.ts",
   "devDependencies": {
     "typescript": "5.3.3"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/adelphes/date-string-fns/issues"
+  },
+  "homepage": "https://github.com/adelphes/date-string-fns#readme",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export function addDate(
  * Convert a local `Date` value into a ISO8601 date string
  */
 export function fromLocalDate(d: Date): string {
-  return buildIsoDateString(d.getDay(), d.getMonth() + 1, d.getFullYear());
+  return buildIsoDateString(d.getDate(), d.getMonth() + 1, d.getFullYear());
 }
 
 /**
@@ -159,7 +159,7 @@ export function fromLocalDate(d: Date): string {
  */
 export function fromUTCDate(d: Date): string {
   return buildIsoDateString(
-    d.getUTCDay(),
+    d.getUTCDate(),
     d.getUTCMonth() + 1,
     d.getUTCFullYear()
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,8 +180,18 @@ function toDate(
     millis = Math.trunc((s - seconds) * 1000);
   }
   return type === 'local'
-    ? new Date(year, month - 1, day, h, m, seconds, millis)
-    : new Date(Date.UTC(year, month - 1, day, h, m, seconds, millis));
+    ? new Date(year, month - 1, day, h ?? 0, m ?? 0, seconds ?? 0, millis ?? 0)
+    : new Date(
+        Date.UTC(
+          year,
+          month - 1,
+          day,
+          h ?? 0,
+          m ?? 0,
+          seconds ?? 0,
+          millis ?? 0
+        )
+      );
 }
 
 /**


### PR DESCRIPTION
- Fix functions used to fetch day of month when parsing Date objects.
- Pass zeroes to Date constructors when no time values are specified
  - without this, the Date instance is returned as `Invalid Date`